### PR TITLE
Switch from LoadBalancer to ClusterIP

### DIFF
--- a/todolist-goof/k8s/java-goof.yaml
+++ b/todolist-goof/k8s/java-goof.yaml
@@ -29,7 +29,7 @@ metadata:
     app: goof
   name: goof
 spec:
-  type: LoadBalancer
+  type: ClusterIP
   ports:
     - port: 80
       protocol: TCP


### PR DESCRIPTION
This prevents the `goof` service from being accessible from the internet.

`kubectl port-forward service/goof 8000:80` can be used instead.