### PR TITLE
Convert to in-memory H2 db

### DIFF
--- a/todolist-goof/todolist-core/pom.xml
+++ b/todolist-goof/todolist-core/pom.xml
@@ -57,9 +57,9 @@
         </dependency>
 
         <dependency>
-            <groupId>org.hsqldb</groupId>
-            <artifactId>hsqldb</artifactId>
-            <version>2.3.2</version>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>1.4.195</version>
         </dependency>
 
         <dependency>

--- a/todolist-goof/todolist-core/src/main/resources/META-INF/persistence.xml
+++ b/todolist-goof/todolist-core/src/main/resources/META-INF/persistence.xml
@@ -5,9 +5,9 @@
     <persistence-unit name="todolist_pu" transaction-type="RESOURCE_LOCAL">
         <provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
         <properties>
-            <property name="hibernate.dialect" value="org.hibernate.dialect.HSQLDialect"/>
-            <property name="hibernate.connection.url" value="jdbc:hsqldb:mem:todolist"/>
-            <property name="hibernate.connection.driver_class" value="org.hsqldb.jdbcDriver"/>
+            <property name="hibernate.dialect" value="org.hibernate.dialect.H2Dialect"/>
+            <property name="hibernate.connection.url" value="jdbc:h2:mem:todolist"/>
+            <property name="hibernate.connection.driver_class" value="org.h2.Driver"/>
             <property name="hibernate.connection.username" value="sa"/>
             <property name="hibernate.connection.password" value=""/>
         </properties>

--- a/todolist-goof/todolist-core/src/main/resources/config/database.properties
+++ b/todolist-goof/todolist-core/src/main/resources/config/database.properties
@@ -1,5 +1,5 @@
-#HSQL in-memory db
-db.driver=org.hsqldb.jdbcDriver
-db.url=jdbc:hsqldb:mem:todolist
+#H2 db
+db.driver=org.h2.Driver
+db.url=jdbc:h2:mem:todolist
 db.username=sa
 db.password=

--- a/todolist-goof/todolist-core/src/main/resources/config/hibernate.properties
+++ b/todolist-goof/todolist-core/src/main/resources/config/hibernate.properties
@@ -1,4 +1,4 @@
-hibernate.dialect=org.hibernate.dialect.HSQLDialect
+hibernate.dialect=org.hibernate.dialect.H2Dialect
 hibernate.show_sql=false
 hibernate.format_sql=false
 hibernate.use_sql_comments=true


### PR DESCRIPTION
Initial refactor to use in-memory H2 database in place of hsql.

This is in prep for subsequent PR for having the option of running 2-tier via docker-compose / k8s w/out need seperate SQL as hsql vs. mysql would need.